### PR TITLE
Add noarch

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,9 +14,6 @@ build:
   number: 1
   noarch: generic
   script: build.sh
-  skip:
-    - win
-    - osx
 
 tests:
   - script:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,7 +11,8 @@ source:
   sha256: d1af6dbc79df740f56667e5b3e1501003cbbf9957f214debb5556bd7eb24167e
 
 build:
-  number: 0
+  number: 1
+  noarch: generic
   script: build.sh
   skip:
     - win


### PR DESCRIPTION
This PR updates the shs-cassini-headers recipe to use noarch: generic

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
